### PR TITLE
Fix syncing the encfs6 file to b2

### DIFF
--- a/archivist.sh
+++ b/archivist.sh
@@ -579,10 +579,11 @@ do
         if [ -z "$(get_option_value "encrypt")" ]
         then
             echo "encrypt=$recipient_encrypt" >> "$config_file_per_recipient"
-            if [ "$recipient_encrypt" == "true" ]
-            then
-                echo "encfs6=$backup_dir/.encfs6.xml.encrypted.cpt" >> "$config_file_per_recipient"
-            fi
+        fi
+
+        if [ "$recipient_encrypt" == "true" ]
+        then
+            echo "encfs6=$backup_dir/.encfs6.xml.encrypted.cpt" >> "$config_file_per_recipient"
         fi
 
         # Include files in the list

--- a/senders/b2.sender.sh
+++ b/senders/b2.sender.sh
@@ -73,9 +73,9 @@ exclude_list=${exclude_list::-1}
 # SEND ARCHIVES TO THE RECIPIENT
 #=================================================
 
-echo "> Copy backups files to b2://$b2_bucket/$dest_directory."
+echo "> Copy backups files to b2://$b2_bucket/$dest_directory/archivist"
 
-b2 sync --noProgress --delete --excludeRegex "$exclude_list" $backup_source b2://$b2_bucket/$dest_directory
+b2 sync --noProgress --delete --excludeRegex "$exclude_list" $backup_source b2://$b2_bucket/$dest_directory/archivist
 
 #=================================================
 # SEND .ENCFS6.XML TO THE RECIPIENT
@@ -83,5 +83,12 @@ b2 sync --noProgress --delete --excludeRegex "$exclude_list" $backup_source b2:/
 
 if [ "$(get_option_value "encrypt")" == "true" ]
 then
-    b2 sync --noProgress --delete "$(get_option_value "encfs6")" b2://$b2_bucket/$dest_directory
+    if [ -z "$(get_option_value "encfs6")" ]
+    then
+      echo "ERROR: encyption configured but encfs6 is empty!"
+    else
+      echo "> Copy encfs6 file to b2://$b2_bucket/$dest_directory/.encfs6.xml.encrypted.cpt"
+
+      b2 upload-file --noProgress $b2_bucket "$(get_option_value "encfs6")" $dest_directory/.encfs6.xml.encrypted.cpt
+    fi
 fi


### PR DESCRIPTION
The `encfs6` option was not being set if the sender had `encrypt` set. This was causing the b2 sender to send up the whole home directory (apparently it's the default if you don't pass anything). I also changed the b2 sender to sync the data and encfs6 file to different directories so they don't overwrite each other.