### PR TITLE
Allow to choose the compression algorithm

### DIFF
--- a/Backup_list.conf.default
+++ b/Backup_list.conf.default
@@ -14,6 +14,35 @@ encrypt=true
 # This file should be set at chmod 400
 cryptpass="/file/which/contains/password"
 
+# Compression algorithm to use
+# gzip
+#   Standard compression algorithm.
+#   Fast and light on ressources.
+# lzop
+#   Very fast algorithm.
+#   Low efficency
+# zstd
+#   Zstandard algorithm
+#   Similar to gzip but faster
+# bzip2
+#   Very slow but very effective.
+#   Light on ressources.
+# lzma
+#   Faster than bzip2 and even more effective.
+#   But demanding in resources.
+# lzip
+#   Similar to lzma.
+# xz
+#   Similar to lzma but more recent.
+#
+# none
+#   No compression
+#   Concatenation in a tar file only
+#
+# Default: gzip
+ynh_compression_mode=gzip
+files_compression_mode=gzip
+
 # --------------------------------------------------------------------------------------
 ## YUNOHOST BACKUPS
 

--- a/Configuration.md
+++ b/Configuration.md
@@ -20,6 +20,9 @@ The file which contains the password for encryption.
 This file should be set at chmod 400 to restrict the read access only to root.  
 Not needed if encrypt is not set to true.
 
+* ### ynh_compression_mode= and files_compression_mode=
+Allow to choose the compression formats to use for YunoHost backups and files and directories backups.
+
 * ### ynh_core_backup=
 *true or false*  
 Make a backup of the core of YunoHost with `yunohost backup create --ignore-app`

--- a/Configuration_fr.md
+++ b/Configuration_fr.md
@@ -20,6 +20,9 @@ Le fichier qui contient le mot de passe pour le chiffrage.
 Ce fichier devrait être réglé sur un chmod 400 pour restreindre sa lecture à root seulement.  
 Pas nécessaire si encrypt n'est pas réglé à true.
 
+* ### ynh_compression_mode= et files_compression_mode=
+Permet de choisir les formats de compressions pour les sauvegardes YunoHost et les sauvegardes de fichiers et de répertoires.
+
 * ### ynh_core_backup=
 *true or false*  
 Créer une sauvegarde du coeur de YunoHost avec `yunohost backup create --ignore-app`

--- a/quick_install.sh
+++ b/quick_install.sh
@@ -32,7 +32,7 @@ sudo git clone https://github.com/maniackcrudelis/archivist "$final_path"
 # INSTALL DEPENDENCIES
 #=================================================
 
-sudo apt-get install rsync encfs sshpass ccrypt
+sudo apt-get install rsync encfs sshpass ccrypt lzop zstd lzip
 
 #=================================================
 # SETUP LOGROTATE


### PR DESCRIPTION
Allow to select the compression algorithm for `tar` between gzip, lzop, zstd, bzip2, lzma, lzip, xz or no compression.

To use lzop, zstd or lzip. Those packages have to be installed: `lzop`, `zstd` or `lzip`.

And force compression for Yunohost backups