### PR TITLE
Allow symlink for no compression

### DIFF
--- a/Backup_list.conf.default
+++ b/Backup_list.conf.default
@@ -38,6 +38,14 @@ cryptpass="/file/which/contains/password"
 # none
 #   No compression
 #   Concatenation in a tar file only
+# symlink
+#   No compression
+#   Symbolic link to the YunoHost tar file from /home/yunohost.backup/archives
+#   The symbolic link is used only for the local $backup_dir of archivist.
+#   Real tar files are send to recipients.
+#
+#   This mode allow archivist to not duplicate locally the backup if not compressed.
+#   WARNING: Does not work with encryption !
 #
 # Default: gzip
 ynh_compression_mode=gzip

--- a/senders/local.sender.sh
+++ b/senders/local.sender.sh
@@ -66,7 +66,7 @@ comm -23 <(sort "$script_dir/../liste") <(sort "$files_list") > "$script_dir/../
 
 echo "> Copy backups files in $dest_directory."
 
-sudo rsync --archive --verbose --human-readable --stats --itemize-changes \
+sudo rsync --archive --copy-links --verbose --human-readable --stats --itemize-changes \
 	--delete-excluded --prune-empty-dirs --exclude-from="$script_dir/../exclude_list" \
 	"$backup_source/" "$dest_directory"
 

--- a/senders/rsync_ssh.sender.sh
+++ b/senders/rsync_ssh.sender.sh
@@ -97,7 +97,7 @@ comm -23 <(sort "$script_dir/../liste") <(sort "$files_list") > "$script_dir/../
 
 echo "> Copy backups files in $dest_directory."
 
-sudo rsync --archive --verbose --human-readable --stats --itemize-changes \
+sudo rsync --archive --copy-links --verbose --human-readable --stats --itemize-changes \
 	--delete-excluded --prune-empty-dirs --exclude-from="$script_dir/../exclude_list" \
 	"$backup_source/" --rsh="$ssh_command $ssh_options" $ssh_user@$ssh_host:"$dest_directory"
 


### PR DESCRIPTION
Fix https://github.com/YunoHost-Apps/archivist_ynh/issues/31

Allow to use a symbolic link instead of a local copy of the tar file for YunoHost backup that are already backed up.
This allow to reduce the size of the backup directory by not duplicate locally the tar YunoHost backups.

However, this can't be used with encryption, as an encrypted symbolic link does not contain anymore the link to the original file...