### PR TITLE
Add space in log between each backup

### DIFF
--- a/archivist.sh
+++ b/archivist.sh
@@ -418,6 +418,7 @@ backup_checksum () {
     local backup_cmd="$1"
     local temp_backup_dir="$backup_dir/ynh_backup/temp"
     # Make a temporary backup
+    echo ""
     echo ">> Make a temporary backup for $backup_name"
     sudo rm -rf "$temp_backup_dir"
     if ! $backup_cmd --methods copy --output-directory "$temp_backup_dir" --name $backup_name.temp > /dev/null


### PR DESCRIPTION
This increases readability of the log (received by email) by separating each block.
It allows for a quick visual scan of the content.